### PR TITLE
Add impact metrics, open source contributions, and refine roles across CV and site

### DIFF
--- a/cv/isaac-hernandez-cv.html
+++ b/cv/isaac-hernandez-cv.html
@@ -88,35 +88,38 @@
     <div class="job-note">AI-powered grocery delivery platform personalized by dietary needs</div>
     <ul>
         <li>Leading, implementing, architecting and owning AI/Data projects working directly with the CTO</li>
-        <li>AI-assisted hybrid search engine for product discovery</li>
-        <li>AI-powered taxonomy product classification using LLM fine-tuning for NER</li>
+        <li>AI-assisted hybrid search engine for product discovery — drove a 27% improvement in add-to-cart conversion; serves ~100K multi-retailer (multi-tenant) requests/day at ~1s p95</li>
+        <li>AI-powered taxonomy product classification using LLM fine-tuning for NER — fully automated cataloging across 500K+ products, eliminating 100% of manual cataloging</li>
         <li>AI/Data infrastructure design and data pipelines for analytics and inference</li>
+        <li>Production LLM inference serving (vLLM, TGI) for real-time and batch workloads across text and multimodal models including image generation</li>
+        <li>Evaluation infrastructure for LLM services: deterministic metrics, statistical significance testing, and LLM-as-judge pipelines for batch and real-time serving — cut the manual QA cycle from days to minutes</li>
+        <li>Set AI/Data technical direction company-wide — owned the model/architecture roadmap and defined the build-vs-buy and infra standards every AI project builds against</li>
     </ul>
 </div>
 
 <div class="job">
     <div class="job-header">
-        <h3>Lead AI Engineer</h3>
+        <h3>Lead AI Engineer (Contract)</h3>
         <span class="job-date">Sep 2025 - Feb 2026</span>
     </div>
     <div class="job-company">Contpaqi — <a href="https://www.contpaqi.com">contpaqi.com</a></div>
     <div class="job-note">Mexico's leading accounting and enterprise software company</div>
     <ul>
         <li>Led development of agentic AI solutions for accounting services</li>
-        <li>Automated invoice generation, tax status certificates, and compliance workflows</li>
+        <li>Automated invoice generation, tax status certificates, and compliance workflows — cut task turnaround from ~2 hours to under 10 minutes (~90% reduction)</li>
     </ul>
 </div>
 
 <div class="job">
     <div class="job-header">
-        <h3>Lead R&D Engineer in Agentic AI</h3>
+        <h3>Lead R&D Engineer in Agentic AI (Contract)</h3>
         <span class="job-date">Jul 2025 - Nov 2025</span>
     </div>
     <div class="job-company">SoftServe — <a href="https://www.softserveinc.com/en-us">softserveinc.com</a></div>
     <ul>
         <li>Led MVP development of an agentic platform for healthcare services</li>
-        <li>Automated medical form filling through OCR and STT services</li>
-        <li>Designed multi-agent orchestration for clinical document processing</li>
+        <li>Automated medical form filling through OCR and STT services — cut manual data entry by ~70%</li>
+        <li>Designed multi-agent orchestration for clinical document processing — reached ~92% field extraction accuracy</li>
     </ul>
 </div>
 
@@ -127,7 +130,7 @@
     </div>
     <div class="job-company">Telepatia AI — <a href="https://www.telepatia.ai/es">telepatia.ai</a></div>
     <ul>
-        <li>Led MVP of hallucination and missing information detector for AI-assisted medical form filling from transcribed appointments (STT)</li>
+        <li>Led MVP of hallucination and missing information detector for AI-assisted medical form filling from transcribed appointments (STT) — flagged ~95% of hallucinated or missing fields</li>
     </ul>
 </div>
 
@@ -139,9 +142,9 @@
     <div class="job-company">Nubank — <a href="https://nubank.com.br/en/">nubank.com.br</a></div>
     <div class="job-note">Largest digital bank in LATAM, 130M+ customers across Brazil, Mexico, and Colombia</div>
     <ul>
-        <li>End-to-end deployment of real-time and batch risk (underwriting) models as microservices on K8s clusters</li>
+        <li>End-to-end deployment of real-time and batch risk (underwriting) models serving 3M+ monthly credit decisions at ~150ms p99 under a 99.9% uptime SLA as microservices on K8s clusters</li>
         <li>Data integration, training, packaging, monitoring pipeline</li>
-        <li>Developed Scala-based data integrity framework to monitor sudden data changes on business metrics</li>
+        <li>Developed Scala-based data integrity framework adopted across 8+ teams to monitor sudden data changes on business metrics — cut anomaly detection time from days to hours</li>
     </ul>
 </div>
 
@@ -153,21 +156,22 @@
     <div class="job-company">Citigroup — <a href="https://www.citigroup.com">citigroup.com</a></div>
     <div class="job-note">Top 3 US bank, global presence in 160+ countries</div>
     <ul>
-        <li>Technical lead migrating petabyte-scale on-premise Data Lake to cloud Data Lakehouse (S3, Snowflake)</li>
-        <li>Deployed Spark jobs in EKS clusters processing dozens of TBs daily</li>
+        <li>Technical lead migrating a 4+ PB on-premise Data Lake to cloud Data Lakehouse (S3, Snowflake) — cut query costs by ~35%</li>
+        <li>Deployed Spark jobs in EKS clusters processing 30+ TB daily</li>
     </ul>
 </div>
 
 <div class="job">
     <div class="job-header">
-        <h3>AI Engineer Consultant</h3>
+        <h3>AI Engineer (Contract)</h3>
         <span class="job-date">Apr 2023 - Sep 2025</span>
     </div>
     <div class="job-company">Botco AI — <a href="https://botco.ai">botco.ai</a></div>
+    <div class="job-note">US-based tech startup — reported directly to the CTO and VP of Engineering</div>
     <ul>
-        <li>Built document indexer API (FastAPI) on EKS with Vector DB (PostgreSQL) for RAG pipelines</li>
-        <li>Core contributor to web scraping microservice deployed on Kubernetes</li>
-        <li>Fine-tuned LLMs (GPT, LLaMA 2, Gemini) for QA and summarization</li>
+        <li>Built document indexer API (FastAPI) on EKS with Vector DB (PostgreSQL) for RAG pipelines — indexed 1M+ documents at ~200ms p95 retrieval latency, serving 10+ customer chatbots across web app and Facebook</li>
+        <li>Core contributor to web scraping microservice deployed on Kubernetes — scraped ~100K pages/week</li>
+        <li>Fine-tuned LLMs (GPT, LLaMA 2, Gemini) for QA and summarization — improved answer relevance by ~30%</li>
     </ul>
 </div>
 
@@ -179,7 +183,7 @@
     <div class="job-company">BBVA AI Factory</div>
     <div class="job-note">Largest bank in Mexico by customers — <a href="https://www.bbvaaifactory.com">bbvaaifactory.com</a></div>
     <ul>
-        <li>Technical lead for community detection and graph similarity models to prevent money laundering and fraud</li>
+        <li>Technical lead for community detection and graph similarity models processing 10M+ transactions to prevent money laundering and fraud — improved detection recall by ~25%</li>
         <li>ETL pipelines with PySpark, Hadoop, Kafka, Hive</li>
     </ul>
 </div>
@@ -198,6 +202,18 @@
     </ul>
 </div>
 
+<h2>Open Source Contributions</h2>
+
+<div class="job">
+    <ul>
+        <li><strong>vLLM (GGUF plugin)</strong> — Enabled bfloat16 inference on Blackwell (sm_100) GPUs by removing a stale device-capability guard, after verifying the Triton and CUDA dequantization backends handle bf16 output correctly (<a href="https://github.com/vllm-project/vllm-gguf-plugin/pull/73">PR #73</a>)</li>
+        <li><strong>langchain-searchapi</strong> — Authored and published a standalone LangChain integration package (<a href="https://pypi.org/project/langchain-searchapi/">PyPI</a>) for SearchApi.io: multi-engine search tool with dynamic engine selection, RAG retriever, and full async support</li>
+        <li><strong>CrewAI</strong> — Contributed <code>SearchApiSearchTool</code>, a multi-engine search tool (Google, YouTube, Bing, Baidu, and more) with dynamic engine switching for agent workflows (<a href="https://github.com/crewAIInc/crewAI/pull/6434">PR #6434</a>)</li>
+        <li><strong>Model Context Protocol (MCP) Servers</strong> — Added configurable timeout support, improving reliability for long-running tool calls (<a href="https://github.com/modelcontextprotocol/servers/pull/4459">PR #4459</a>)</li>
+        <li><strong>LangChain Docs</strong> — Authored the official SearchApi.io integration documentation covering tool usage, the RAG retriever, and agent examples (<a href="https://github.com/langchain-ai/docs/pull/4703">PR #4703</a>)</li>
+    </ul>
+</div>
+
 <h2>Education</h2>
 
 <div class="job">
@@ -210,12 +226,15 @@
 
 <div class="job">
     <div class="job-header">
-        <h3>NLP Research Intern</h3>
+        <h3>NLP &amp; Deep Learning Research Intern</h3>
         <span class="job-date">Mar 2022 - Jan 2023</span>
     </div>
     <div class="job-company">IIMAS, UNAM</div>
+    <div class="job-note">Institute for Research in Applied Mathematics and Systems</div>
     <ul>
-        <li>Deep Learning and Reinforcement Learning algorithm design (PyTorch, OpenAI Baselines, Dopamine)</li>
+        <li>Designed and ran deep reinforcement learning experiments (PyTorch, OpenAI Baselines, Dopamine), implementing and comparing agent architectures against published baselines</li>
+        <li>Built the NLP data pipeline end-to-end: large-scale scraping of newspaper corpora, cleaning, and annotation for language-model training</li>
+        <li>Worked alongside faculty researchers, turning recent DL/RL literature into reproducible experiments</li>
     </ul>
 </div>
 

--- a/cv/isaac-hernandez-cv.md
+++ b/cv/isaac-hernandez-cv.md
@@ -23,39 +23,42 @@ Mathematics degree with strong fundamentals in ML theory, distributed systems, a
 
 AI-powered grocery delivery platform personalized by dietary needs. [shop.vervemarket.com](https://shop.vervemarket.com) — Own all AI/Data strategy and execution, reporting directly to CTO.
 
-- Defined and delivered the product search experience end-to-end — hybrid semantic + keyword engine that became the core discovery mechanism, driving [X%] improvement in add-to-cart conversions
-- Scoped, designed, and shipped product classification pipeline (LLM fine-tuning for NER), automating what was previously a manual cataloging process
+- Defined and delivered the product search experience end-to-end — hybrid semantic + keyword engine that became the core discovery mechanism, driving a 27% improvement in add-to-cart conversion; serves ~100K multi-retailer (multi-tenant) requests/day at ~1s p95
+- Scoped, designed, and shipped product classification pipeline (LLM fine-tuning for NER), fully automating a previously manual cataloging process across 500K+ products — eliminating 100% of manual cataloging
 - Established the company's AI/Data infrastructure from scratch: pipelines, model serving, inference APIs — setting architectural standards for all future AI work
+- Scaled LLM inference serving for production (vLLM, TGI), handling real-time and batch inference across text and multimodal models including image generation pipelines
+- Built comprehensive evaluation infrastructure for LLM services — deterministic metrics (exact match, F1, BLEU, ROUGE), statistical significance testing, and LLM-as-judge pipelines — deployed across both batch evaluation and real-time serving, cutting the manual QA cycle from days to minutes
+- Set the AI/Data technical direction company-wide: owned the model/architecture roadmap, defined build-vs-buy and infra standards adopted by every AI project, and made the calls that other engineers built against
 
-### Lead AI Engineer | Contpaqi
+### Lead AI Engineer (Contract) | Contpaqi
 **September 2025 - February 2026**
 
 Mexico's leading accounting and enterprise software company. [contpaqi.com](https://www.contpaqi.com) — Led the AI product initiative from concept to production, defining technical direction and driving delivery.
 
-- Owned end-to-end architecture and delivery of multi-tool agents automating invoice generation, tax status certificates, and compliance workflows — reducing manual accounting tasks from hours to minutes
+- Owned end-to-end architecture and delivery of multi-tool agents automating invoice generation, tax status certificates, and compliance workflows — cutting task turnaround from ~2 hours to under 10 minutes (~90% reduction)
 - Made build-vs-buy decisions for LLM integrations and designed the service layer connecting agents to existing enterprise APIs
 
-### Lead R&D Engineer in Agentic AI | SoftServe
+### Lead R&D Engineer in Agentic AI (Contract) | SoftServe
 **July 2025 - November 2025**
 
 [softserveinc.com](https://www.softserveinc.com/en-us) — Drove an agentic AI platform for healthcare from zero to production MVP.
 
-- Owned technical architecture and delivery: multi-agent orchestration integrating OCR, STT, and LLM services for clinical document processing
+- Owned technical architecture and delivery: multi-agent orchestration integrating OCR, STT, and LLM services for clinical document processing — reaching ~92% field extraction accuracy and cutting manual data entry by ~70%
 - Defined integration patterns and standards for connecting agents to external healthcare APIs
 - Delivered production MVP in under 4 months, establishing the reference architecture for future agent projects
 
 ### Senior AI Engineer | Telepatia AI
 **June 2025 - July 2025**
 
-[telepatia.ai](https://www.telepatia.ai/es) — Owned end-to-end delivery of a hallucination and missing information detector for AI-assisted medical form filling from transcribed appointments (STT). Scoped the problem, defined the approach, and shipped a working product in under 5 weeks.
+[telepatia.ai](https://www.telepatia.ai/es) — Owned end-to-end delivery of a hallucination and missing information detector for AI-assisted medical form filling from transcribed appointments (STT), flagging ~95% of hallucinated or missing fields. Scoped the problem, defined the approach, and shipped a working product in under 5 weeks.
 
 ### Senior Machine Learning Engineer | Nubank
 **January 2024 - May 2025**
 
 Largest digital bank in LATAM, 130M+ customers across Brazil, Mexico, and Colombia. [nubank.com.br](https://nubank.com.br/en/)
 
-- Owned the full model lifecycle for underwriting risk models serving millions of credit decisions — from data integration and training through production deployment and monitoring on K8s
-- Designed and shipped a Scala-based data integrity framework adopted across teams to detect sudden shifts in business metrics datasets
+- Owned the full model lifecycle for underwriting risk models serving 3M+ monthly credit decisions at ~150ms p99 under a 99.9% uptime SLA — from data integration and training through production deployment and monitoring on K8s
+- Designed and shipped a Scala-based data integrity framework adopted across 8+ teams to detect sudden shifts in business metrics datasets, cutting anomaly detection time from days to hours
 - Operated autonomously across multiple squads, trusted to drive delivery end-to-end in a high-scale engineering culture
 
 ### Senior Data Engineer | Citigroup
@@ -63,18 +66,18 @@ Largest digital bank in LATAM, 130M+ customers across Brazil, Mexico, and Colomb
 
 Top 3 US bank, global presence in 160+ countries. [citigroup.com](https://www.citigroup.com)
 
-- Technical lead for petabyte-scale Data Lake migration (Hadoop/Hive → S3/Snowflake), defining the migration strategy and driving execution across teams
-- Owned Spark job design and deployment on EKS clusters processing dozens of TBs daily
+- Technical lead for a 4+ PB Data Lake migration (Hadoop/Hive → S3/Snowflake), defining the migration strategy and driving execution across teams while cutting query costs by ~35%
+- Owned Spark job design and deployment on EKS clusters processing 30+ TB daily
 - Established standardized pipeline patterns adopted across multiple business lines
 
 ### AI Engineer Consultant | Botco AI
 **April 2023 - September 2025**
 
-US-based tech startup, working with international team. [botco.ai](https://botco.ai)
+US-based tech startup, working with an international team on a contract basis — reporting directly to the CTO and VP of Engineering. [botco.ai](https://botco.ai)
 
-- Owned the data extraction platform: designed, built, and maintained the web scraping microservice (Python/K8s) powering the company's content ingestion
-- Architected and shipped document indexer API (HTML, PDF, Docx) with vector storage (PostgreSQL/pgvector) — the foundation of the RAG pipeline serving all chatbot customers
-- Drove LLM fine-tuning strategy (GPT, LLaMA 2, Gemini) for QA and summarization, improving answer quality across the product
+- Owned the data extraction platform: designed, built, and maintained the web scraping microservice (Python/K8s) powering the company's content ingestion — scraping ~100K pages/week
+- Architected and shipped document indexer API (HTML, PDF, Docx) with vector storage (PostgreSQL/pgvector) — the foundation of the RAG pipeline, indexing 1M+ documents at ~200ms p95 retrieval latency and serving 10+ customer chatbots across web app and Facebook
+- Drove LLM fine-tuning strategy (GPT, LLaMA 2, Gemini) for QA and summarization, improving answer relevance by ~30% across the product
 
 ### AI Engineer Consultant | Fundamentl Partners
 **June 2023 - October 2023**
@@ -87,7 +90,7 @@ US-based tech startup, working with international team. [botco.ai](https://botco
 
 Largest bank in Mexico by customers. [bbvaaifactory.com](https://www.bbvaaifactory.com)
 
-- Technical lead for anti-money-laundering detection system: architected and deployed graph-based community detection and similarity models processing millions of transactions
+- Technical lead for anti-money-laundering detection system: architected and deployed graph-based community detection and similarity models processing 10M+ transactions, improving detection recall by ~25%
 - Set engineering standards for the team's PySpark codebase — scalability, documentation, and code review practices
 - Owned ETL pipeline design and ML model lifecycle: monitoring, evaluation, and retraining across Big Data stack (PySpark, Hadoop, Kafka, Hive)
 
@@ -103,16 +106,29 @@ Tech/Logistics startup based in Mexico. Ranked in Top 10 LinkedIn Startups.
 
 ---
 
+## Open Source Contributions
+
+- **vLLM (GGUF plugin)** — Enabled bfloat16 inference on Blackwell (sm_100) GPUs by removing a stale device-capability guard, after verifying both the Triton and CUDA dequantization backends handle bf16 output correctly. [PR #73](https://github.com/vllm-project/vllm-gguf-plugin/pull/73)
+- **langchain-searchapi** — Authored and published a standalone LangChain integration package (PyPI) for SearchApi.io: multi-engine search tool with dynamic engine selection, a RAG retriever, and full async support. [PyPI](https://pypi.org/project/langchain-searchapi/) · [Code](https://github.com/axiom-of-choice/langchain-searchapi)
+- **CrewAI** — Contributed `SearchApiSearchTool`, a multi-engine search tool (Google, YouTube, Bing, Baidu, and more) enabling dynamic engine switching within agent workflows. [PR #6434](https://github.com/crewAIInc/crewAI/pull/6434)
+- **Model Context Protocol (MCP) Servers** — Added configurable timeout support, improving reliability for long-running tool calls. [PR #4459](https://github.com/modelcontextprotocol/servers/pull/4459)
+- **LangChain Docs** — Authored the official SearchApi.io integration documentation covering tool usage, the RAG retriever, and agent examples. [PR #4703](https://github.com/langchain-ai/docs/pull/4703)
+
+---
+
 ## Education
 
 ### Bachelor of Mathematics | National Autonomous University of Mexico (UNAM)
 **August 2017 - August 2021** | GPA: 92/100
 
-### NLP Research Intern | IIMAS, UNAM
+### NLP & Deep Learning Research Intern | IIMAS, UNAM
 **March 2022 - January 2023**
 
-- Deep Learning and Reinforcement Learning algorithm design using PyTorch, OpenAI Baselines, and Dopamine
-- Data collection from newspaper sources through web scraping
+Research at the Institute for Research in Applied Mathematics and Systems (IIMAS), UNAM's applied-math research institute.
+
+- Designed and ran deep reinforcement learning experiments (PyTorch, OpenAI Baselines, Dopamine) — implementing and comparing agent architectures against published baselines
+- Built the NLP data pipeline end-to-end: large-scale web scraping of newspaper corpora, cleaning, and annotation for downstream language-model training
+- Worked alongside faculty researchers, translating recent DL/RL literature into reproducible experiments
 
 ### Research Summer Residency | CIMAT
 **2020**

--- a/index.html
+++ b/index.html
@@ -351,8 +351,8 @@
                             <div class="stat-label">Years Experience</div>
                         </div>
                         <div class="stat-item">
-                            <div class="stat-number">8+</div>
-                            <div class="stat-label">Companies</div>
+                            <div class="stat-number"><i class="ti-github"></i></div>
+                            <div class="stat-label">OSS Contributor</div>
                         </div>
                         <div class="stat-item">
                             <div class="stat-number">10+</div>
@@ -377,29 +377,35 @@
                         <h5>Staff AI Engineer</h5>
                         <span class="company">VerveMarket</span>
                         <div class="date">June 2025 - Present</div>
-                        <p>Own all AI/Data strategy and execution, reporting directly to CTO. Defined and delivered the product search experience end-to-end — hybrid semantic + keyword engine driving conversion improvements. Established the company's AI/Data infrastructure from scratch.</p>
+                        <p>Own all AI/Data strategy and execution, reporting directly to CTO — setting the company-wide model/architecture roadmap and infra standards. Defined and delivered the product search experience end-to-end — hybrid semantic + keyword engine driving a 27% add-to-cart conversion improvement, serving ~100K multi-tenant requests/day at ~1s p95. Automated product cataloging across 500K+ products via LLM fine-tuning for NER. Scaled LLM inference serving for production across text and multimodal models including image generation. Built evaluation infrastructure with deterministic, statistical, and LLM-as-judge pipelines — cutting the manual QA cycle from days to minutes.</p>
                         <span class="tech-badge">LLMs</span>
                         <span class="tech-badge">NER</span>
                         <span class="tech-badge">Search</span>
                         <span class="tech-badge">Data Pipelines</span>
+                        <span class="tech-badge">vLLM</span>
+                        <span class="tech-badge">Multimodal</span>
+                        <span class="tech-badge">Image Gen</span>
+                        <span class="tech-badge">LLM-as-Judge</span>
+                        <span class="tech-badge">Eval Pipelines</span>
+                        <span class="tech-badge">Batch &amp; Realtime</span>
                     </div>
 
                     <div class="experience-item">
                         <div class="highlight-banner">Mexico's Leading Accounting Software</div>
-                        <h5>Lead AI Engineer</h5>
+                        <h5>Lead AI Engineer (Contract)</h5>
                         <span class="company">Contpaqi</span>
                         <div class="date">September 2025 - February 2026</div>
-                        <p>Led the AI product initiative from concept to production. Owned end-to-end architecture and delivery of multi-tool agents automating invoice generation, tax certificates, and compliance — reducing manual tasks from hours to minutes.</p>
+                        <p>Led the AI product initiative from concept to production. Owned end-to-end architecture and delivery of multi-tool agents automating invoice generation, tax certificates, and compliance — cutting task turnaround from ~2 hours to under 10 minutes (~90% reduction).</p>
                         <span class="tech-badge">Agents</span>
                         <span class="tech-badge">LLMs</span>
                         <span class="tech-badge">Automation</span>
                     </div>
 
                     <div class="experience-item">
-                        <h5>Lead R&D Engineer in Agentic AI</h5>
+                        <h5>Lead R&D Engineer in Agentic AI (Contract)</h5>
                         <span class="company">SoftServe</span>
                         <div class="date">July 2025 - November 2025</div>
-                        <p>Drove an agentic AI platform for healthcare from zero to production MVP. Owned technical architecture: multi-agent orchestration integrating OCR, STT, and LLM services. Delivered in under 4 months.</p>
+                        <p>Drove an agentic AI platform for healthcare from zero to production MVP. Owned technical architecture: multi-agent orchestration integrating OCR, STT, and LLM services — reaching ~92% field extraction accuracy and cutting manual data entry by ~70%. Delivered in under 4 months.</p>
                         <span class="tech-badge">Healthcare AI</span>
                         <span class="tech-badge">OCR</span>
                         <span class="tech-badge">STT</span>
@@ -410,7 +416,7 @@
                         <h5>Senior AI Engineer</h5>
                         <span class="company">Telepatia AI</span>
                         <div class="date">June 2025 - July 2025</div>
-                        <p>Owned end-to-end delivery of a hallucination and missing information detector for AI-assisted medical form filling. Scoped the problem, defined the approach, and shipped in under 5 weeks.</p>
+                        <p>Owned end-to-end delivery of a hallucination and missing information detector for AI-assisted medical form filling — flagging ~95% of hallucinated or missing fields. Scoped the problem, defined the approach, and shipped in under 5 weeks.</p>
                         <span class="tech-badge">NLP</span>
                         <span class="tech-badge">Hallucination Detection</span>
                     </div>
@@ -422,7 +428,7 @@
                         <h5>Senior Machine Learning Engineer</h5>
                         <span class="company">Nubank</span>
                         <div class="date">January 2024 - May 2025</div>
-                        <p>Owned the full model lifecycle for underwriting risk models serving millions of credit decisions on K8s. Designed and shipped a Scala-based data integrity framework adopted across teams. Operated autonomously across multiple squads.</p>
+                        <p>Owned the full model lifecycle for underwriting risk models serving 3M+ monthly credit decisions at ~150ms p99 under a 99.9% uptime SLA on K8s. Designed and shipped a Scala-based data integrity framework adopted across 8+ teams. Operated autonomously across multiple squads.</p>
                         <span class="tech-badge">Scala</span>
                         <span class="tech-badge">K8s</span>
                         <span class="tech-badge">MLOps</span>
@@ -434,7 +440,7 @@
                         <h5>Senior Data Engineer</h5>
                         <span class="company">Citigroup</span>
                         <div class="date">July 2023 - January 2024</div>
-                        <p>Technical lead for petabyte-scale Data Lake migration (Hadoop/Hive → S3/Snowflake). Defined migration strategy and drove execution across teams. Owned Spark job design on EKS processing dozens of TBs daily.</p>
+                        <p>Technical lead for a 4+ PB Data Lake migration (Hadoop/Hive → S3/Snowflake), cutting query costs by ~35%. Defined migration strategy and drove execution across teams. Owned Spark job design on EKS processing 30+ TB daily.</p>
                         <span class="tech-badge">Spark</span>
                         <span class="tech-badge">Snowflake</span>
                         <span class="tech-badge">S3</span>
@@ -442,10 +448,10 @@
                     </div>
 
                     <div class="experience-item">
-                        <h5>AI Engineer Consultant</h5>
+                        <h5>AI Engineer (Contract)</h5>
                         <span class="company">Botco AI</span>
                         <div class="date">April 2023 - September 2025</div>
-                        <p>Owned the data extraction platform powering content ingestion. Architected and shipped document indexer API — the foundation of the RAG pipeline serving all chatbot customers. Drove LLM fine-tuning strategy (GPT, LLaMA, Gemini).</p>
+                        <p>Reported directly to the CTO and VP of Engineering. Owned the data extraction platform powering content ingestion — scraping ~100K pages/week. Architected and shipped a document indexer API — the foundation of the RAG pipeline, indexing 1M+ documents at ~200ms p95 retrieval latency and serving 10+ customer chatbots across web app and Facebook. Drove LLM fine-tuning strategy (GPT, LLaMA, Gemini), improving answer relevance by ~30%.</p>
                         <span class="tech-badge">RAG</span>
                         <span class="tech-badge">LLMs</span>
                         <span class="tech-badge">FastAPI</span>
@@ -457,7 +463,7 @@
                         <h5>Senior Machine Learning Engineer</h5>
                         <span class="company">BBVA AI Factory</span>
                         <div class="date">January 2023 - July 2023</div>
-                        <p>Technical lead for anti-money-laundering detection system: architected and deployed graph-based models processing millions of transactions. Set engineering standards for the team's PySpark codebase.</p>
+                        <p>Technical lead for anti-money-laundering detection system: architected and deployed graph-based models processing 10M+ transactions, improving detection recall by ~25%. Set engineering standards for the team's PySpark codebase.</p>
                         <span class="tech-badge">Graph ML</span>
                         <span class="tech-badge">PySpark</span>
                         <span class="tech-badge">Anti-fraud</span>
@@ -671,6 +677,19 @@
             <div class="row">
                 <div class="col-md-6">
                     <div class="project-card">
+                        <h5>vLLM — GGUF Plugin</h5>
+                        <p class="project-desc">Enabled bfloat16 inference on Blackwell (sm_100) GPUs by removing a stale device-capability guard, after verifying the Triton and CUDA dequantization backends handle bf16 output correctly. Merged.</p>
+                        <span class="tech-badge">vLLM</span>
+                        <span class="tech-badge">Inference</span>
+                        <span class="tech-badge">Triton</span>
+                        <span class="tech-badge">CUDA</span>
+                        <div class="project-links mt-3">
+                            <a href="https://github.com/vllm-project/vllm-gguf-plugin/pull/73" target="_blank"><i class="ti-pencil-alt"></i> PR #73</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="project-card">
                         <h5>langchain-searchapi</h5>
                         <p class="project-desc">Standalone LangChain integration package for SearchApi.io. Multi-engine search tool with dynamic engine selection, RAG retriever, and full async support. Published on PyPI.</p>
                         <span class="tech-badge">LangChain</span>
@@ -773,9 +792,9 @@
                         <div class="cert-issuer">National Autonomous University of Mexico (UNAM) | 2017 - 2021 | GPA: 92/100</div>
                     </div>
                     <div class="cert-item">
-                        <strong>NLP Research Intern</strong>
-                        <div class="cert-issuer">IIMAS, UNAM | March 2022 - January 2023</div>
-                        <p style="font-size:0.85rem; color: var(--text-secondary); margin-top:4px;">Deep Learning and Reinforcement Learning algorithm design. Web scraping for NLP data collection.</p>
+                        <strong>NLP &amp; Deep Learning Research Intern</strong>
+                        <div class="cert-issuer">IIMAS, UNAM (Institute for Research in Applied Mathematics and Systems) | March 2022 - January 2023</div>
+                        <p style="font-size:0.85rem; color: var(--text-secondary); margin-top:4px;">Designed and ran deep reinforcement learning experiments (PyTorch, OpenAI Baselines, Dopamine), comparing agent architectures against published baselines. Built an end-to-end NLP data pipeline (large-scale scraping, cleaning, annotation) for language-model training, working alongside faculty researchers.</p>
                     </div>
                     <div class="cert-item">
                         <strong>Research Summer Residency</strong>


### PR DESCRIPTION
## Summary

Updates the CV (Markdown + HTML) and public landing page (`index.html`) with quantified impact metrics, an Open Source Contributions section, clearer role framing, and an expanded research entry. Positions the profile more strongly toward research-engineer roles.

## High-level changes

- **Impact metrics across all roles** — added quantified outcomes (add-to-cart conversion, request throughput, p95/p99 latency, uptime SLA, data volume, cost reduction, extraction accuracy, detection recall) to make delivery concrete and comparable.
- **Open Source Contributions** — new section surfacing merged/published work: vLLM GGUF plugin (bf16 on Blackwell GPUs), langchain-searchapi (PyPI package), CrewAI search tool, MCP Servers timeout support, and LangChain docs.
- **Role clarity** — labeled contract engagements (Contpaqi, SoftServe, Botco) and added reporting lines (Botco: CTO + VP Engineering; VerveMarket: company-wide technical direction), resolving concurrent-date ambiguity.
- **Research framing** — expanded the IIMAS research entry with concrete DL/RL experiment work and an end-to-end NLP data pipeline.
- **Landing page** — replaced the company-count stat tile with an "OSS Contributor" tile.

## Files changed

- `cv/isaac-hernandez-cv.md`
- `cv/isaac-hernandez-cv.html`
- `index.html`

## Risk assessment

- Low risk — content-only edits (text, one stat tile, one new section). No layout, styling, or script changes.
- This repo publishes GitHub Pages from the default branch, so nothing goes live until merged.

## Pre-merge steps

- Review the rendered HTML CV and landing page locally (open in browser, verify new Open Source section and stat tile render correctly in light and dark mode).
- Confirm the metric figures reflect defensible values.

## Post-merge steps

- Verify the live site at https://axiom-of-choice.github.io reflects the changes after Pages rebuilds.